### PR TITLE
included new directories in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # python notebooks
 *.ipynb
 
-# data directory (for now)
+# directories (for now)
 /data
+/output


### PR DESCRIPTION
gitignore used to only include the /data directory present in the root. This is what contains the datasets used to train, evaluate, and test the model on local machines, and will be generated from running the process_data.py script. 

gitignore also now includes the model directory, which houses everything related to the model. This can also be created by running the train.py script that will be pushed to the main branch soon