### PR TITLE
include new directories in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # python notebooks
 *.ipynb
 
-# data directory (for now)
+# directories (for now, may change)
 /data
+/output


### PR DESCRIPTION
redoes a previously done pr that was accidentally removed during a rebase. the /data folder was added to the gitignore so that large datasets are not uploaded to the repository. running the data processing script will collect the datasets on the local machine so uploading them to the repo doesn't make sense

added the model folder to the gitignore now that a model has been trained. accidentally pushing the model to the repository would require additional configuration that hasn't been done.